### PR TITLE
Fix default value treatment to make it easier to add new fields

### DIFF
--- a/tests/test_dataclass_serializer.py
+++ b/tests/test_dataclass_serializer.py
@@ -17,7 +17,7 @@ class Item(Serializable):
 
 @dataclasses.dataclass
 class ItemWithDefault(Serializable):
-    value: int = dataclasses.field(default=1)
+    value: Optional[int] = dataclasses.field(default=1)
 
 
 @dataclasses.dataclass
@@ -96,10 +96,20 @@ def test_serializable_with_default():
 
     assert deserialize(expect) == ItemWithDefault(value=1)
 
-    # if serialized data missing field, but there is default value then allow to
-    # deserialize with default value.
+    # Case when entity is already serialized before, then later on you added new field to the
+    # entity with new default value. In this case, we want to deserialize entity with filling
+    # new field with None.
+
     missing = {"__ser__": "test_dataclass_serializer:ItemWithDefault"}
-    assert deserialize(missing) == ItemWithDefault(value=1)
+    assert deserialize(missing) == ItemWithDefault(value=None)
+
+    # Test case with not optional value
+    with pytest.raises(ValueError) as e:
+        missing = {"__ser__": "test_dataclass_serializer:Item"}
+        deserialize(missing)
+
+    assert 'unknown' in str(e.value)
+
 
 
 def test_serializable_with_default_factory():


### PR DESCRIPTION
Basically we want to extend entity with keep deserialized object's
behavior consistend even after you changed the entity. Case when
entity's default value is used when serialized field (previous
implementation), your serialized model's behavior is depends on
the default value and you cannot change its default value forever
if you want to keep deserialized entity's behavior compatible.
With this changes, it will be much easier, with adding field
with optional type.